### PR TITLE
opfido-81 make callbackurl optional

### DIFF
--- a/app/pipelines/run_routes.py
+++ b/app/pipelines/run_routes.py
@@ -20,7 +20,7 @@ run_bp = Blueprint("pipeline-runs", __name__)
 
 
 @run_bp.route("/<pipeline_uuid>/runs", methods=["POST"])
-@verify_content_type_and_params(["inputs", "callback_url"], [])
+@verify_content_type_and_params(["inputs"], ["callback_url"])
 @permissions_required([SystemPermissionEnum.PIPELINES_CLIENT])
 def create_run(pipeline_uuid):
     """Create a new pipeline run.


### PR DESCRIPTION
Makes `callbackurl` optional when creating a pipeline run