### PR TITLE
Let workers handle unexpected errs; adds run-worker task opfido-251

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ update its status (generated in the instructions above).
 
 Endpoints have been documented with [swagger](https://swagger.io/blog/news/whats-new-in-openapi-3-0/), which is configured to be easily explored in the default `run.py` configuration. When the flask server is running visit http://localhost:5000/apidocs to see documentation and interact with the API directly.
 
+## Workers
+
+You can use the `run-worker` invoke task to test repositories. For instance, you
+can test the anticipation integration by uploading the 'inputs' of the run to an
+input directory and executing the following command:
+
+    invoke run-worker $PWD/inputs 'slacgrip/master:200527' https://github.com/PresencePG/grip-anticipation-pipeline.git master openfido.sh
+
 ## Configuration
 
 Common settings used by both server and workers:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -163,9 +163,5 @@ def execute_pipeline(
                 executor.upload_artifact(f, join(outputdir, f))
 
         executor.update_run_status(RunStateEnum.COMPLETED)
-    except ValueError as v_e:
-        failed(v_e)
-    except urllib.error.URLError as url_e:
-        failed(url_e)
-    # TODO may need a more generic exception handling here, or possibly
-    # configure signal handling (errors) with celery itself.
+    except Exception as exc:
+        failed(exc)


### PR DESCRIPTION
Try to mark tasks as failed on unhandled exception.

Adds a `run-worker` task to make it easier to test other pipeline
integrations. I imagine this would be a good starting point to making a
CLI tool for pipeline worker integrators at some future date.